### PR TITLE
Rust bump

### DIFF
--- a/dpkg-rs/Cargo.lock
+++ b/dpkg-rs/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"

--- a/dpkg-rs/Cargo.toml
+++ b/dpkg-rs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0.99"
+anyhow = "1.0.100"
 chrono = "0.4.42"
 csv = "1.3.1"
 jsonwebtoken = "9.3.1"


### PR DESCRIPTION
This pull request updates dependency versions in the `dpkg-rs/Cargo.toml` file to keep the project up to date and benefit from the latest improvements and fixes.

Dependency version updates:

* Updated the `anyhow` crate from version `1.0.99` to `1.0.100`.
* Updated the `serde` crate from version `1.0.219` to `1.0.226`, keeping the `derive` feature.